### PR TITLE
Fix compilation-environment warning and add expanded yarn command as completion info

### DIFF
--- a/yarn.el
+++ b/yarn.el
@@ -184,7 +184,7 @@ NIL if they should be looked up from the global path"
   (interactive)
   (setq yarn-vars-add-dep (read-from-minibuffer "Add dev dependency (e.g: tape): " yarn-vars-add-dep))
   (message (concat "Adding dev dependency: " yarn-vars-add-dep))
-  (yarn-exec-with-path 'start-process "yarn-add-dev" "*yarn*" "yarn" "add" yarn-vars-add-dep "-dev"))
+  (yarn-exec-with-path 'start-process "yarn-add-dev" "*yarn*" "yarn" "add" yarn-vars-add-dep "--dev"))
 
 (defun yarn-add-peer ()
   "Add peer dependency"
@@ -198,21 +198,21 @@ NIL if they should be looked up from the global path"
   (interactive)
   (setq yarn-vars-add-dep (read-from-minibuffer "Add optional dependency (e.g: fetch): " yarn-vars-add-dep))
   (message (concat "Adding optional dependency: " yarn-vars-add-dep))
-  (yarn-exec-with-path 'start-process "yarn-add-optional" "*yarn*" "yarn" "add" yarn-vars-add-dep "-optional"))
+  (yarn-exec-with-path 'start-process "yarn-add-optional" "*yarn*" "yarn" "add" yarn-vars-add-dep "--optional"))
 
 (defun yarn-add-exact ()
   "Add exact dependency"
   (interactive)
   (setq yarn-vars-add-dep (read-from-minibuffer "Add exact dependency (e.g: react-router): " yarn-vars-add-dep))
   (message (concat "Adding exact dependency " yarn-vars-add-dep))
-  (yarn-exec-with-path 'start-process "yarn-add-exact" "*yarn*" "yarn" "add" yarn-vars-add-dep "-exact"))
+  (yarn-exec-with-path 'start-process "yarn-add-exact" "*yarn*" "yarn" "add" yarn-vars-add-dep "--exact"))
 
 (defun yarn-add-tilde ()
   "Add exact dependency"
   (interactive)
   (setq yarn-vars-add-dep (read-from-minibuffer "Add tilde dependency (e.g: react): " yarn-vars-add-dep))
   (message (concat "Adding tilde dependency " yarn-vars-add-dep))
-  (yarn-exec-with-path 'start-process "yarn-add-tilde" "*yarn*" "yarn" "global" "add" yarn-vars-add-dep "-tilde"))
+  (yarn-exec-with-path 'start-process "yarn-add-tilde" "*yarn*" "yarn" "global" "add" yarn-vars-add-dep "--tilde"))
 
 (defun yarn-global-add ()
   "Add dependency globally"
@@ -226,14 +226,14 @@ NIL if they should be looked up from the global path"
   (interactive)
   (setq yarn-vars-add-dep (read-from-minibuffer "Add global exact dependency (e.g: react-router): " yarn-vars-add-dep))
   (message (concat "Adding exact dependency " yarn-vars-add-dep))
-  (yarn-exec-with-path 'start-process "yarn-global-add-exact" "*yarn*" "yarn" "global" "add" yarn-vars-add-dep "-exact"))
+  (yarn-exec-with-path 'start-process "yarn-global-add-exact" "*yarn*" "yarn" "global" "add" yarn-vars-add-dep "--exact"))
 
 (defun yarn-global-add-tilde ()
   "Add exact dependency globally"
   (interactive)
   (setq yarn-vars-add-dep (read-from-minibuffer "Add global tilde dependency (e.g: react): " yarn-vars-add-dep))
   (message (concat "Adding tilde dependency " yarn-vars-add-dep))
-  (yarn-exec-with-path 'start-process "yarn-global-add-tilde" "*yarn*" "yarn" "global" "add" yarn-vars-add-dep "-tilde"))
+  (yarn-exec-with-path 'start-process "yarn-global-add-tilde" "*yarn*" "yarn" "global" "add" yarn-vars-add-dep "--tilde"))
 
 (defun yarn-parse-dependency (input)
   (let (name ver dev)
@@ -573,7 +573,7 @@ SCRIPT can be passed in or selected from a list of scripts configured in a packa
   (save-some-buffers (not compilation-ask-about-save)
                      (when (boundp 'compilation-save-buffers-predicate)
                        compilation-save-buffers-predicate))
-  (-let* (((scripts docs) (yarn-parse-scripts (process-lines "yarn" "run")))
+  (-let* (((scripts docs) (yarn-parse-scripts (yarn-exec-with-path 'process-lines "yarn" "run")))
           (completion-extra-properties
            (list :annotation-function
                  (lambda (s)

--- a/yarn.el
+++ b/yarn.el
@@ -63,12 +63,14 @@ NIL if they should be looked up from the global path"
 (defun yarn-exec-with-path (callback &rest args)
   "Execute CALLBACK with the path set to YARN_EXECUTABLE_PATH."
   (let ((exec-path (if yarn-executable-path
-                     (cons yarn-executable-path)
-                     exec-path))
-        (compilation-environment (if yarn-executable-path
-                                   (cons (concat "PATH=" yarn-executable-path path-separator (getenv "PATH")) compilation-environment)
-                                   compilation-environment)))
-    (apply callback args)))
+                       (cons yarn-executable-path)
+                     exec-path)))
+    (progn
+      (when yarn-executable-path
+        (setq-local compilation-environment
+                    (cons (concat "PATH=" yarn-executable-path path-separator (getenv "PATH"))
+                          compilation-environment)))
+      (apply callback args))))
 
 (defun yarn-git ()
   (concat "git@github.com:" yarn-vars-git-user "/" yarn-vars-name ".git"))
@@ -547,8 +549,7 @@ From http://benhollis.net/blog/2015/12/20/nodejs-stack-traces-in-emacs-compilati
   "Yarn compilation mode."
   (progn
     (set (make-local-variable 'compilation-error-regexp-alist) yarn-node-error-regexp-alist)
-    (add-hook 'compilation-filter-hook 'yarn-compilation-filter nil t)
-  ))
+    (add-hook 'compilation-filter-hook 'yarn-compilation-filter nil t)))
 
 (defun yarn-parse-scripts (raw-scripts)
   "Parse the output of the `yarn run` command in RAW-SCRIPTS into a list of scripts."

--- a/yarn.el
+++ b/yarn.el
@@ -64,15 +64,9 @@ NIL if they should be looked up from the global path"
 
 (defun yarn-exec-with-path (callback &rest args)
   "Execute CALLBACK with the path set to YARN_EXECUTABLE_PATH."
-  (let ((exec-path (if yarn-executable-path
-                       (cons yarn-executable-path)
-                     exec-path)))
-    (progn
-      (when yarn-executable-path
-        (setq-local compilation-environment
-                    (cons (concat "PATH=" yarn-executable-path path-separator (getenv "PATH"))
-                          compilation-environment)))
-      (apply callback args))))
+  (when yarn-executable-path
+    (setenv "PATH" (concat yarn-executable-path path-separator (getenv "PATH"))))
+  (apply callback args))
 
 (defun yarn-git ()
   (concat "git@github.com:" yarn-vars-git-user "/" yarn-vars-name ".git"))


### PR DESCRIPTION
When calling yarn-run with a completion framework that supports rich information (selectrum, ivy), the expanded form of each script in the package.json will appear on the right of the command.